### PR TITLE
rtsp: fix some msg only have LF in respondDescribe

### DIFF
--- a/rtsp.coffee
+++ b/rtsp.coffee
@@ -1408,9 +1408,9 @@ class RTSPServer
       Cache-Control: no-cache
 
 
-      """.replace /\n/g, "\r\n"
+      """
 
-      callback null, res + body
+      callback null, res.replace /\n/g, "\r\n" + body
 
   respondSetup: (socket, req, callback) ->
     client = @clients[socket.clientID]


### PR DESCRIPTION
Some players can not correctly recognize only have LF in some lines except VLC(live555).